### PR TITLE
Removed module from example index

### DIFF
--- a/examples/ingestAndSearch.js
+++ b/examples/ingestAndSearch.js
@@ -19,7 +19,6 @@ async function createIndex(splunk, index) {
         "version": 1,
         "name": index,
         "kind": "index",
-        "module": "splunk",
         "disabled": false
     };
 


### PR DESCRIPTION
Module was not being used when sending the data, which
routed the data to dead_letter.  Module also needs to
be used when searching the data.