### PR TITLE
fix url builder to include falsy but not null value

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -107,7 +107,6 @@ export class ServiceClient {
                 .filter(k => query[k] != null) // filter out undefined and null
                 .map(k => `${encoder(k)}=${encoder(String(query[k]))}`)
                 .join('&');
-            debugger;
             return `${this.url}${path}?${queryEncoded}`;
         }
         return `${this.url}${path}`;


### PR DESCRIPTION
**Problem:**
`{ offset:0, count:1}` will be translated into `results?&count=1` in url. while it should be `results?offset=0&count=1`

