### PR TITLE
Fix KVStore flaky tests

### DIFF
--- a/examples/ingestAndSearch.js
+++ b/examples/ingestAndSearch.js
@@ -3,7 +3,7 @@
 //              different ways, then runs a search to verify the data was added.
 require("isomorphic-fetch");
 
-const SplunkCloud = require("../splunk");
+const { SplunkCloud } = require("../splunk");
 const { sleep, searchResults } = require("../utils/exampleHelperFunctions");
 
 const { SPLUNK_CLOUD_HOST, BEARER_TOKEN, TENANT_ID } = process.env;

--- a/examples/ingestMetricsAndSearch.js
+++ b/examples/ingestMetricsAndSearch.js
@@ -3,7 +3,7 @@
 //              and a search on the ingested data to verify the data.
 require("isomorphic-fetch");
 
-const SplunkCloud = require("../splunk");
+const { SplunkCloud } = require("../splunk");
 const { searchResults } = require("../utils/exampleHelperFunctions");
 
 const { SPLUNK_CLOUD_HOST, BEARER_TOKEN, TENANT_ID } = process.env;

--- a/src/client.ts
+++ b/src/client.ts
@@ -166,8 +166,10 @@ export class ServiceClient {
                 .filter(k => query[k] != null) // filter out undefined and null
                 .map(k => `${encoder(k)}=${encoder(String(query[k]))}`)
                 .join('&');
+
             return `${this.url}${path}?${queryEncoded}`;
         }
+
         return `${this.url}${path}`;
     }
 
@@ -221,12 +223,14 @@ export class ServiceClient {
      * @param data Body data (will be stringified if an object)
      */
     public fetch(method: HTTPMethod, path: string, opts: RequestOptions = {}, data?: any): Promise<Response> {
-        return fetch(this.buildUrl(path, opts.query), {
+        const url = this.buildUrl(path, opts.query)
+        const options = {
             method,
             headers: this.buildHeaders(opts.headers),
             body: typeof data !== 'string' ? JSON.stringify(data) : data,
-        })
-            .then(response => this.invokeHooks(response));
+        }
+
+        return fetch(url, options).then(response => this.invokeHooks(response));
 
     }
 
@@ -318,7 +322,7 @@ export interface RequestOptions {
 }
 
 export interface QueryArgs {
-    [key: string]: string | number | undefined | boolean;
+    [key: string]: string | number | boolean | undefined;
 }
 
 export enum ContentType {

--- a/src/kvstore.ts
+++ b/src/kvstore.ts
@@ -5,7 +5,7 @@ without a valid written license from Splunk Inc. is PROHIBITED.
 */
 
 import BaseApiService from './baseapiservice';
-import { ContentType, HTTPResponse, QueryArgs, RequestHeaders } from './client';
+import { ContentType, HTTPResponse, QueryArgs, RequestHeaders, RequestOptions } from './client';
 import { KVSTORE_SERVICE_PREFIX } from './service_prefixes';
 
 /**
@@ -169,7 +169,10 @@ export class KVStoreService extends BaseApiService {
             collection,
             'query',
         ]);
-        return this.client.get(url, filter)
+        const requestOptions: RequestOptions = {
+            query: filter
+        }
+        return this.client.get(url, requestOptions)
             .then(response => response.body as Map<string, string>);
     };
 
@@ -199,7 +202,10 @@ export class KVStoreService extends BaseApiService {
             'collections',
             collection,
         ]);
-        return this.client.get(url, filter)
+        const requestOptions: RequestOptions = {
+            query: filter
+        }
+        return this.client.get(url, requestOptions)
             .then(response => response.body as Map<string, string>);
     };
 
@@ -210,11 +216,11 @@ export class KVStoreService extends BaseApiService {
      * @returns A promise that will be resolved when the matching records are deleted
      */
     public deleteRecords = (collection: string, filter?: QueryArgs): Promise<any> => {
-        return this.client.delete(
-            this.client.buildPath(KVSTORE_SERVICE_PREFIX, ['collections', collection, 'query']),
-            filter
-        )
-            .then(response => response.body);
+        const url = this.client.buildPath(KVSTORE_SERVICE_PREFIX, ['collections', collection, 'query'])
+        const requestOptions: RequestOptions = {
+            query: filter
+        }
+        return this.client.delete(url, requestOptions).then(response => response.body);
     };
 
     /**

--- a/test/integration/catalog_proxy.js
+++ b/test/integration/catalog_proxy.js
@@ -202,6 +202,30 @@ function createKVCollectionDataset(namespace, collection) {
     );
 }
 
+function deleteAllDatasets() {
+    // Gets the datasets
+    return (
+        splunkCloud.catalog
+            .getDatasets()
+            // Deletes the dataset there should only be one dataset
+            .then(datasets => {
+                return Promise.all(
+                    datasets.map(dataset => {
+                        return splunkCloud.catalog.deleteDataset(dataset.id);
+                    })
+                );
+            })
+            // Finally set the dataset for testing
+            .then(response => {
+                return response;
+            })
+            .catch(error => {
+                console.log('An error was encountered while cleaning up datasests');
+                console.log(error);
+            })
+    );
+}
+
 function createRecord(collection, record) {
     return splunkCloud.kvstore
         .insertRecord(collection, record)
@@ -259,4 +283,5 @@ module.exports = {
     createKVCollectionDataset: createKVCollectionDataset,
     createRecord: createRecord,
     createRule: createRule,
+    deleteAllDatasets: deleteAllDatasets,
 };

--- a/test/integration/kvstore_collections_proxy.js
+++ b/test/integration/kvstore_collections_proxy.js
@@ -10,7 +10,7 @@ const testNamespace = config.testNamespace;
 const testCollection = config.testCollection;
 
 const { ContentType } = require('../../client');
-const { createKVCollectionDataset, createRecord } = require('./catalog_proxy');
+const { createKVCollectionDataset, createRecord, deleteAllDatasets } = require('./catalog_proxy');
 
 const splunkCloud = new SplunkCloud(splunkCloudHost, token, tenantID);
 
@@ -36,16 +36,11 @@ describe('Integration tests for KVStore Collection Endpoints', () => {
         TEST_KEY_03: 'B',
     };
 
-    beforeEach(async () => {
-        testDataset = await createKVCollectionDataset(testNamespace, testCollection);
-        return testDataset;
-    });
-    afterEach(() => {
-        if (testDataset != null) {
-            return splunkCloud.catalog
-                .deleteDatasetByName(testDataset.name)
-                .catch(err => console.log(`Error cleaning the test dataset: ${err}`));
-        }
+    beforeEach(() => {
+        return deleteAllDatasets().then(response => {
+            testDataset = createKVCollectionDataset(testNamespace, testCollection);
+            return testDataset
+        })
     });
 
     // -------------------------------------------------------------------------

--- a/test/integration/kvstore_query_proxy.js
+++ b/test/integration/kvstore_query_proxy.js
@@ -9,7 +9,7 @@ const tenantID = config.playgroundTenant;
 const testNamespace = config.testNamespace;
 const testCollection = config.testCollection;
 
-const { createKVCollectionDataset, createRecord } = require('./catalog_proxy');
+const { createKVCollectionDataset, createRecord, deleteAllDatasets } = require('./catalog_proxy');
 
 const splunkCloud = new SplunkCloud(splunkCloudHost, token, tenantID)
 
@@ -35,16 +35,11 @@ describe('Integration tests for KVStore Query Endpoints', () => {
         TEST_KEY_03: 'B',
     };
 
-    beforeEach(async () => {
-        testDataset = await createKVCollectionDataset(testNamespace, testCollection);
-        return testDataset;
-    });
-    afterEach(() => {
-        if (testDataset != null) {
-            return splunkCloud.catalog
-                .deleteDatasetByName(testDataset.name)
-                .catch(err => console.log(`Error cleaning the test dataset: ${err}`));
-        }
+    beforeEach(() => {
+        return deleteAllDatasets().then(response => {
+            testDataset = createKVCollectionDataset(testNamespace, testCollection);
+            return testDataset
+        })
     });
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Added `deleteAllDatasets` to catalog testing helpers.
Changed kvstore collection tests to delete all datasets before running each test.
Changed kvstore query record tests to delete all datasets before running each test.
Changed `examples/ingestMetricsAndSearch.js` to import SplunkCloud correctly.
Changed `examples/ingestAndSearch.js` to import SplunkCloud correctly.
Changed kvstore functions using query parameters to correctly pass query arguments.