### PR TITLE
Use valid mode for autokv action

### DIFF
--- a/test/integration/catalog_proxy.js
+++ b/test/integration/catalog_proxy.js
@@ -314,9 +314,9 @@ describe('catalog tests', () => {
             return splunkCloud.catalog.createRuleAction(
                 ruleId,
                 {
-                    mode: 'mymode', 'kind': 'AUTOKV'
+                    mode: 'auto', 'kind': 'AUTOKV'
                 }).then(act => {
-                    assert(act.mode, 'mymode');
+                    assert(act.mode, 'auto');
                 });
         });
 


### PR DESCRIPTION
Mode is now constrained to the types that are accepted by splunkd